### PR TITLE
add spacing and adjust cols for skill on phone screen

### DIFF
--- a/components/ui/skill-item.tsx
+++ b/components/ui/skill-item.tsx
@@ -30,7 +30,7 @@ const SkillItem: React.FC<SkillItemProps> = ({
         </div>
         <div className="relative pt-1">
           <div className="mb-2 flex items-center justify-between">
-            <div>
+            <div className="flex items-center gap-1">
               <span className="py-1 text-sm font-medium text-gray-500 dark:text-gray-400 sm:inline-block">
                 {category}
               </span>

--- a/components/ui/skill-set.tsx
+++ b/components/ui/skill-set.tsx
@@ -69,7 +69,7 @@ const SkillSet = () => {
       <h3 className="mb-8 w-full text-center text-3xl text-blue-900 underline dark:text-white">
         {currentLang === "ja" ? "スキル" : "Skills"}
       </h3>
-      <div className="mx-auto grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
+      <div className="mx-auto grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
         {filteredSkills.map((skill) => (
           <SkillItem
             key={skill.name}
@@ -88,7 +88,7 @@ const SkillSet = () => {
           {currentLang === "ja" ? "その他のスキル" : "Other Skills"}
         </h3>
       )}
-      <div className="mx-auto grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
+      <div className="mx-auto grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
         {filteredOtherSkills.map((otherSkill) => (
           <SkillItem
             key={otherSkill.name}

--- a/components/ui/skill-set.tsx
+++ b/components/ui/skill-set.tsx
@@ -88,7 +88,7 @@ const SkillSet = () => {
           {currentLang === "ja" ? "その他のスキル" : "Other Skills"}
         </h3>
       )}
-      <div className="mx-auto grid gap-6 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
+      <div className="mx-auto grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
         {filteredOtherSkills.map((otherSkill) => (
           <SkillItem
             key={otherSkill.name}

--- a/components/ui/skill-set.tsx
+++ b/components/ui/skill-set.tsx
@@ -69,7 +69,7 @@ const SkillSet = () => {
       <h3 className="mb-8 w-full text-center text-3xl text-blue-900 underline dark:text-white">
         {currentLang === "ja" ? "スキル" : "Skills"}
       </h3>
-      <div className="mx-auto grid gap-6 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
+      <div className="mx-auto grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
         {filteredSkills.map((skill) => (
           <SkillItem
             key={skill.name}

--- a/components/ui/skill-set.tsx
+++ b/components/ui/skill-set.tsx
@@ -69,7 +69,7 @@ const SkillSet = () => {
       <h3 className="mb-8 w-full text-center text-3xl text-blue-900 underline dark:text-white">
         {currentLang === "ja" ? "スキル" : "Skills"}
       </h3>
-      <div className="mx-auto grid grid-cols-3 gap-6 md:grid-cols-4 lg:grid-cols-4">
+      <div className="mx-auto grid gap-6 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
         {filteredSkills.map((skill) => (
           <SkillItem
             key={skill.name}
@@ -88,7 +88,7 @@ const SkillSet = () => {
           {currentLang === "ja" ? "その他のスキル" : "Other Skills"}
         </h3>
       )}
-      <div className="mx-auto grid grid-cols-3 gap-6 md:grid-cols-4 lg:grid-cols-4">
+      <div className="mx-auto grid gap-6 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4">
         {filteredOtherSkills.map((otherSkill) => (
           <SkillItem
             key={otherSkill.name}


### PR DESCRIPTION
This pull request includes updates to the layout and styling of skill-related components in the UI. The changes improve responsiveness and visual alignment across different screen sizes.

### Layout improvements:

* [`components/ui/skill-set.tsx`](diffhunk://#diff-903d9bd4ade4439c333831ca8fd402f15146a714a9530a0eb21d3bc0ccbf7b91L72-R72): Updated the grid layout for `SkillSet` and `Other Skills` sections to use `sm:grid-cols-2` for better responsiveness on smaller screens. This replaces the previous fixed `grid-cols-3` configuration. [[1]](diffhunk://#diff-903d9bd4ade4439c333831ca8fd402f15146a714a9530a0eb21d3bc0ccbf7b91L72-R72) [[2]](diffhunk://#diff-903d9bd4ade4439c333831ca8fd402f15146a714a9530a0eb21d3bc0ccbf7b91L91-R91)

### Styling enhancements:

* [`components/ui/skill-item.tsx`](diffhunk://#diff-24c2e087f0dc8e7d295b1d09666f1c99f16e4ef559acda38f7d9a3901c2023e4L33-R33): Modified the `SkillItem` component to use a `flex` container with `gap-1` for better alignment and spacing between elements in the skill category display.